### PR TITLE
Manejar OPENAI_API_KEY y documentar su uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # INTRODUCCION_AGENTES
+
+Este proyecto requiere la variable de entorno `OPENAI_API_KEY` para acceder a la API de OpenAI.
+
+## Configuración
+
+Establece la variable de entorno antes de ejecutar el código:
+
+```bash
+export OPENAI_API_KEY="tu_api_key"
+```
+
+## Pruebas
+
+Para ejecutar las pruebas unitarias:
+
+```bash
+pytest
+```

--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,0 +1,11 @@
+import os
+
+
+def ensure_openai_api_key():
+    """Verifica que la variable OPENAI_API_KEY esté configurada.
+
+    Raises:
+        EnvironmentError: si la variable no existe o está vacía.
+    """
+    if not os.getenv("OPENAI_API_KEY"):
+        raise EnvironmentError("Falta OPENAI_API_KEY en variables de entorno.")

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import importlib
+
+import pytest
+
+# Ensure project root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import openai_utils
+
+
+def test_raises_when_key_missing(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with pytest.raises(EnvironmentError):
+        openai_utils.ensure_openai_api_key()
+
+
+def test_passes_when_key_present(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    openai_utils.ensure_openai_api_key()


### PR DESCRIPTION
## Summary
- Añadir utilidad que verifica `OPENAI_API_KEY` y lanza `EnvironmentError` si falta
- Documentar cómo configurar la variable de entorno y cómo ejecutar pruebas
- Agregar pruebas unitarias para validar el comportamiento de la verificación

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48f7ef8f4832683dc7edc25ac96c8