### PR TITLE
Implement PIRJO multi-agent introduction assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
 # INTRODUCCION_AGENTES
 
-
-Este proyecto requiere la variable de entorno `OPENAI_API_KEY` para acceder a la API de OpenAI.
+Asistente de Introducciones de Investigación (PIRJO). El sistema analiza PDFs proporcionados y genera una introducción académica siguiendo los bloques PIRJO (Propósito, Importancia, Relevancia, Justificación, Originalidad).
 
 ## Configuración
 
-Establece la variable de entorno antes de ejecutar el código:
+Este proyecto requiere la variable de entorno `OPENAI_API_KEY` para acceder a la API de OpenAI:
 
 ```bash
 export OPENAI_API_KEY="tu_api_key"
 ```
+
+Instala las dependencias necesarias ejecutando:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso
+
+Ejecuta la aplicación Gradio:
+
+```bash
+python main.py
+```
+
+La interfaz permite ingresar el título del trabajo, subir archivos PDF y obtener la introducción final, los bloques PIRJO intermedios y la lista de documentos procesados.
 
 ## Pruebas
 
@@ -17,12 +32,4 @@ Para ejecutar las pruebas unitarias:
 
 ```bash
 pytest
-
-## Instalación
-
-Instala las dependencias necesarias ejecutando:
-
-```bash
-pip install -r requirements.txt
-
 ```

--- a/app.py
+++ b/app.py
@@ -1,8 +1,34 @@
+from typing import List
+
 import gradio as gr
 
-with gr.Blocks() as demo:
-    with gr.Row():
-        titulo = gr.Markdown("Sube tus archivos")
-        files = gr.File(label="Seleccionar archivo")
+from pirjo_pipeline import generate_introduction
 
-demo.launch()
+
+def run_pipeline(title: str, files: List[gr.File]) -> tuple:
+    """Execute the PIRJO pipeline and format outputs for Gradio."""
+    file_paths = [f.name for f in files] if files else []
+    if not title or not file_paths:
+        return "Se requiere título y al menos un PDF.", "", ""
+    result = generate_introduction(title, file_paths)
+    blocks_text = "\n".join(f"{k}: {v}" for k, v in result["blocks"].items())
+    processed = ", ".join(result["files"])
+    return result["introduction"], blocks_text, processed
+
+
+def build_demo() -> gr.Blocks:
+    with gr.Blocks() as demo:
+        gr.Markdown("### Asistente de Introducciones de Investigación (PIRJO)")
+        with gr.Row():
+            title = gr.Textbox(label="Título del trabajo")
+            pdfs = gr.File(label="PDFs", file_count="multiple", file_types=[".pdf"])
+        btn = gr.Button("Generar Introducción")
+        intro = gr.Textbox(label="Introducción", lines=8)
+        blocks = gr.Textbox(label="Bloques PIRJO", lines=8)
+        files_out = gr.Textbox(label="Archivos procesados")
+        btn.click(run_pipeline, inputs=[title, pdfs], outputs=[intro, blocks, files_out])
+    return demo
+
+
+if __name__ == "__main__":
+    build_demo().launch()

--- a/main.py
+++ b/main.py
@@ -1,11 +1,15 @@
 """Entry point for the INTRODUCCION_AGENTES application."""
 
-# Dependencies are managed via requirements.txt.
-# Removed runtime installation: '!pip -q install -U crewai crewai-tools gradio'
+from openai_utils import ensure_openai_api_key
+from app import build_demo
 
-def main():
-    """Run a placeholder CrewAI application."""
-    print("CrewAI app placeholder")
+
+def main() -> None:
+    """Launch the Gradio PIRJO assistant."""
+    ensure_openai_api_key()
+    demo = build_demo()
+    demo.launch()
+
 
 if __name__ == "__main__":
     main()

--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -1,0 +1,82 @@
+import json
+import os
+from typing import List, Dict
+
+import openai
+from PyPDF2 import PdfReader
+
+from openai_utils import ensure_openai_api_key
+
+
+def _call_openai(prompt: str, system: str = "") -> str:
+    """Helper to call OpenAI chat completion and return content."""
+    messages = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": prompt})
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    return response["choices"][0]["message"]["content"].strip()
+
+
+def extract_sources(files: List[str]) -> List[Dict[str, str]]:
+    """Extract text and citation info from PDF files."""
+    sources = []
+    for path in files:
+        reader = PdfReader(path)
+        for idx, page in enumerate(reader.pages, start=1):
+            text = page.extract_text() or ""
+            sources.append({"file": os.path.basename(path), "page": idx, "text": text})
+    return sources
+
+
+def analista_de_fuentes(title: str, sources: List[Dict[str, str]]) -> str:
+    """Run the source analysis agent and return bullets with citations."""
+    compiled = "".join(
+        f"[{s['file']}:{s['page']}]\n{s['text']}\n\n" for s in sources if s["text"].strip()
+    )
+    prompt = (
+        f"Título de investigación: {title}\n\n"
+        "A partir de los textos con su cita entre corchetes, extrae conceptos, datos y hallazgos "
+        "relevantes. Responde en viñetas breves y termina cada viñeta con la cita correspondiente."\
+    ) + "\n\n" + compiled
+    return _call_openai(prompt, system="Agente Analista de Fuentes")
+
+
+def metodologo_pirjo(bullets: str) -> Dict[str, str]:
+    """Transform bullets into PIRJO blocks."""
+    prompt = (
+        "Convierte las viñetas siguientes en bloques PIRJO. Cada bloque debe contener 2-3 "
+        "oraciones claras. Responde estrictamente en JSON con las claves P, I, R, J, O.\n\n"
+        f"Viñetas:\n{bullets}"
+    )
+    content = _call_openai(prompt, system="Agente Metodólogo PIRJO")
+    try:
+        blocks = json.loads(content)
+    except json.JSONDecodeError:
+        # if parsing fails, return content under a generic key
+        blocks = {"error": content}
+    return blocks
+
+
+def redactor_academico(blocks: Dict[str, str]) -> str:
+    """Create the final introduction from PIRJO blocks."""
+    prompt = (
+        "Eres un redactor académico. Con los bloques PIRJO dados en formato JSON, escribe una "
+        "introducción cohesionada de 2-3 párrafos en estilo formal. Asegúrate de incluir las "
+        "citas cuando se proporcionen en los bloques.\n\n" + json.dumps(blocks, ensure_ascii=False)
+    )
+    return _call_openai(prompt, system="Agente Redactor Académico")
+
+
+def generate_introduction(title: str, file_paths: List[str]) -> Dict[str, str]:
+    """Orchestrate the PIRJO pipeline and return results."""
+    ensure_openai_api_key()
+    sources = extract_sources(file_paths)
+    bullets = analista_de_fuentes(title, sources)
+    blocks = metodologo_pirjo(bullets)
+    introduction = redactor_academico(blocks)
+    return {
+        "introduction": introduction,
+        "blocks": blocks,
+        "files": [os.path.basename(p) for p in file_paths],
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 crewai
 crewai-tools
 gradio
+openai
+PyPDF2


### PR DESCRIPTION
## Summary
- Add pipeline to analyze PDFs and generate introductions using PIRJO methodology.
- Build Gradio interface for title and PDF inputs returning introduction, blocks, and file list.
- Update entrypoint, documentation, and dependencies.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49384362083269bf01d3f82cb4250