### PR TITLE
Ensure OPENAI_API_KEY loads from .env and add tests

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -1,11 +1,20 @@
 import os
+from dotenv import load_dotenv
 
 
 def ensure_openai_api_key():
-    """Verifica que la variable OPENAI_API_KEY esté configurada.
+    """Ensure that ``OPENAI_API_KEY`` is available.
+
+    The function first attempts to load variables from a ``.env`` file using
+    :func:`dotenv.load_dotenv`. If the key is still missing, an
+    :class:`EnvironmentError` is raised with guidance on how to set the
+    variable.
 
     Raises:
-        EnvironmentError: si la variable no existe o está vacía.
+        EnvironmentError: If ``OPENAI_API_KEY`` is not defined.
     """
+    load_dotenv()
     if not os.getenv("OPENAI_API_KEY"):
-        raise EnvironmentError("Falta OPENAI_API_KEY en variables de entorno.")
+        raise EnvironmentError(
+            "OPENAI_API_KEY is missing. Create a .env file or set the variable manually."
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ crewai-tools
 gradio
 openai
 PyPDF2
+python-dotenv

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import importlib
+from pathlib import Path
 
 import pytest
 
@@ -11,10 +11,23 @@ import openai_utils
 
 def test_raises_when_key_missing(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with pytest.raises(EnvironmentError):
+    with pytest.raises(EnvironmentError) as excinfo:
         openai_utils.ensure_openai_api_key()
+    # The error message should guide the user to create a .env file or set the variable
+    assert ".env" in str(excinfo.value)
 
 
 def test_passes_when_key_present(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
     openai_utils.ensure_openai_api_key()
+
+
+def test_loads_key_from_env_file(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    env_file = Path(".env")
+    env_file.write_text("OPENAI_API_KEY=from_env_file\n")
+    try:
+        openai_utils.ensure_openai_api_key()
+        assert os.getenv("OPENAI_API_KEY") == "from_env_file"
+    finally:
+        env_file.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- load `OPENAI_API_KEY` via `python-dotenv` in `openai_utils.ensure_openai_api_key`
- provide clearer error prompting users to create a `.env` file or set the variable
- add unit tests for `.env` loading and message content

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a1330b108326ad7f1ab83e8db413