### PR TITLE
Pin legacy OpenAI dependency and document rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ echo $env:OPENAI_API_KEY
 
 La aplicación mostrará un error si la clave sigue sin configurarse.
 
+Este proyecto fija la dependencia `openai` en la versión `0.28.1` porque el código utiliza la API legacy `ChatCompletion`. Si se migra a la nueva versión (`openai>=1.0.0`), será necesario actualizar las llamadas a la API.
+
 Instala las dependencias necesarias ejecutando:
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 crewai
 crewai-tools
 gradio
-openai
+openai==0.28.1
 PyPDF2
 python-dotenv


### PR DESCRIPTION
## Summary
- Pin `openai` dependency to version 0.28.1 for legacy ChatCompletion usage
- Document the pinned version and migration note in README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai==0.28.1; Cannot connect to proxy)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4a439af4c8326b6fa8a18563ed3be