### PR TITLE
feat: add DeepSeek fallback

### DIFF
--- a/openai_utils.py
+++ b/openai_utils.py
@@ -2,19 +2,34 @@ import os
 from dotenv import load_dotenv
 
 
-def ensure_openai_api_key():
-    """Ensure that ``OPENAI_API_KEY`` is available.
+def ensure_openai_api_key() -> None:
+    """Ensure that an API key for OpenAI or DeepSeek is available.
 
     The function first attempts to load variables from a ``.env`` file using
-    :func:`dotenv.load_dotenv`. If the key is still missing, an
-    :class:`EnvironmentError` is raised with guidance on how to set the
-    variable.
+    :func:`dotenv.load_dotenv`. If neither ``OPENAI_API_KEY`` nor
+    ``DEEPSEEK_API_KEY`` is defined, an :class:`EnvironmentError` is raised with
+    guidance on how to set the variable.
 
     Raises:
-        EnvironmentError: If ``OPENAI_API_KEY`` is not defined.
+        EnvironmentError: If no API key is defined.
     """
     load_dotenv()
-    if not os.getenv("OPENAI_API_KEY"):
+    if not (os.getenv("OPENAI_API_KEY") or os.getenv("DEEPSEEK_API_KEY")):
         raise EnvironmentError(
-            "OPENAI_API_KEY is missing. Create a .env file or set the variable manually."
+            "Set OPENAI_API_KEY or DEEPSEEK_API_KEY in a .env file or the environment.",
         )
+
+
+def get_client():
+    """Return an OpenAI-compatible client for OpenAI or DeepSeek.
+
+    Prefers OpenAI when ``OPENAI_API_KEY`` is present; otherwise attempts to use
+    DeepSeek via its OpenAI-compatible endpoint.
+    """
+    ensure_openai_api_key()
+    api_key = os.getenv("OPENAI_API_KEY") or os.getenv("DEEPSEEK_API_KEY")
+    from openai import OpenAI  # Imported here to avoid dependency during tests
+    if os.getenv("OPENAI_API_KEY"):
+        return OpenAI(api_key=api_key)
+    # DeepSeek uses an OpenAI-compatible API
+    return OpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1")

--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -2,12 +2,11 @@ import json
 import os
 from typing import List, Dict
 
-from openai import OpenAI
 from PyPDF2 import PdfReader
 
-from openai_utils import ensure_openai_api_key
+from openai_utils import ensure_openai_api_key, get_client
 
-client = OpenAI()
+client = get_client()
 
 
 def _call_openai(prompt: str, system: str = "") -> str:
@@ -16,7 +15,10 @@ def _call_openai(prompt: str, system: str = "") -> str:
     if system:
         messages.append({"role": "system", "content": system})
     messages.append({"role": "user", "content": prompt})
-    response = client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)
+    model = "gpt-3.5-turbo"
+    if os.getenv("DEEPSEEK_API_KEY") and not os.getenv("OPENAI_API_KEY"):
+        model = "deepseek-chat"
+    response = client.chat.completions.create(model=model, messages=messages)
     return response.choices[0].message.content.strip()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 crewai
 crewai-tools
 gradio
-openai==0.28.1
+openai>=1.0.0
 PyPDF2
 python-dotenv

--- a/tests/test_openai_utils.py
+++ b/tests/test_openai_utils.py
@@ -11,6 +11,7 @@ import openai_utils
 
 def test_raises_when_key_missing(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     with pytest.raises(EnvironmentError) as excinfo:
         openai_utils.ensure_openai_api_key()
     # The error message should guide the user to create a .env file or set the variable
@@ -19,11 +20,19 @@ def test_raises_when_key_missing(monkeypatch):
 
 def test_passes_when_key_present(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "dummy")
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    openai_utils.ensure_openai_api_key()
+
+
+def test_passes_when_deepseek_key_present(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "dummy")
     openai_utils.ensure_openai_api_key()
 
 
 def test_loads_key_from_env_file(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
     env_file = Path(".env")
     env_file.write_text("OPENAI_API_KEY=from_env_file\n")
     try:


### PR DESCRIPTION
## Summary
- allow either OPENAI_API_KEY or DEEPSEEK_API_KEY and provide helper to build appropriate client
- support DeepSeek model in pipeline and update OpenAI requirement
- expand tests to cover DeepSeek key usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5e03e3c8326b30321a828384c9a