### PR TITLE
Implement token-based PDF chunking and prompt limiting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ gradio
 openai>=1.0.0
 PyPDF2
 python-dotenv
+tiktoken


### PR DESCRIPTION
## Summary
- add `chunk_text` to split PDF page text into ~700-token fragments using tiktoken
- include chunk metadata in `extract_sources`
- limit prompt assembly in `analista_de_fuentes` to fit within 12k tokens
- add `tiktoken` to project dependencies

## Testing
- `pip install tiktoken`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b04c46588326afb1e95e3a9a4f0d