### PR TITLE
Implement FAISS-based retrieval for source analysis

### DIFF
--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -5,6 +5,7 @@ from typing import List, Dict
 from PyPDF2 import PdfReader
 
 from openai_utils import ensure_openai_api_key, get_client
+from rag_faiss import ensure_index, search_index
 
 client = get_client()
 
@@ -33,10 +34,10 @@ def extract_sources(files: List[str]) -> List[Dict[str, str]]:
     return sources
 
 
-def analista_de_fuentes(title: str, sources: List[Dict[str, str]]) -> str:
-    """Run the source analysis agent and return bullets with citations."""
+def analista_de_fuentes(title: str, chunks: List[Dict[str, str]]) -> str:
+    """Run the source analysis agent over retrieved chunks and return bullets with citations."""
     compiled = "".join(
-        f"[{s['file']}:{s['page']}]\n{s['text']}\n\n" for s in sources if s["text"].strip()
+        f"[{c['file']}:{c['page']}]\n{c['text']}\n\n" for c in chunks if c["text"].strip()
     )
     prompt = (
         f"Título de investigación: {title}\n\n"
@@ -72,11 +73,22 @@ def redactor_academico(blocks: Dict[str, str]) -> str:
     return _call_openai(prompt, system="Agente Redactor Académico")
 
 
+def retrieve_relevant_chunks(
+    title: str,
+    sources: List[Dict[str, str]],
+    k: int = 5,
+) -> List[Dict[str, str]]:
+    """Retrieve ``k`` chunks relevant to ``title`` using a FAISS index."""
+    index, metadata = ensure_index(sources)
+    return search_index(title, k, index, metadata)
+
+
 def generate_introduction(title: str, file_paths: List[str]) -> Dict[str, str]:
     """Orchestrate the PIRJO pipeline and return results."""
     ensure_openai_api_key()
     sources = extract_sources(file_paths)
-    bullets = analista_de_fuentes(title, sources)
+    chunks = retrieve_relevant_chunks(title, sources)
+    bullets = analista_de_fuentes(title, chunks)
     blocks = metodologo_pirjo(bullets)
     introduction = redactor_academico(blocks)
     return {

--- a/rag_faiss.py
+++ b/rag_faiss.py
@@ -1,0 +1,116 @@
+import json
+import os
+from typing import Dict, List, Tuple
+
+import faiss
+import numpy as np
+
+from openai_utils import get_client
+
+INDEX_FILE = "faiss.index"
+META_FILE = "faiss_meta.json"
+
+
+def _chunk_text(text: str, chunk_size: int = 500, overlap: int = 50) -> List[str]:
+    """Split text into chunks of roughly ``chunk_size`` words with overlap."""
+    words = text.split()
+    chunks: List[str] = []
+    start = 0
+    while start < len(words):
+        end = start + chunk_size
+        chunk = " ".join(words[start:end]).strip()
+        if chunk:
+            chunks.append(chunk)
+        start += chunk_size - overlap
+    return chunks
+
+
+def _embed_text(text: str) -> List[float]:
+    """Return embedding for ``text`` using OpenAI's small embedding model."""
+    client = get_client()
+    response = client.embeddings.create(model="text-embedding-3-small", input=text)
+    return response.data[0].embedding
+
+
+def build_index(
+    sources: List[Dict[str, str]],
+    index_file: str = INDEX_FILE,
+    meta_file: str = META_FILE,
+    chunk_size: int = 500,
+    overlap: int = 50,
+) -> Tuple[faiss.IndexFlatL2, List[Dict[str, str]]]:
+    """Build a FAISS index from sources and persist it along with metadata."""
+    embeddings: List[np.ndarray] = []
+    metadata: List[Dict[str, str]] = []
+    for src in sources:
+        for idx, chunk in enumerate(_chunk_text(src["text"], chunk_size, overlap)):
+            emb = np.array(_embed_text(chunk), dtype="float32")
+            embeddings.append(emb)
+            metadata.append({
+                "file": src["file"],
+                "page": src["page"],
+                "chunk": idx,
+                "text": chunk,
+            })
+    if not embeddings:
+        dim = 0
+        index = faiss.IndexFlatL2(0)
+    else:
+        emb_matrix = np.vstack(embeddings)
+        dim = emb_matrix.shape[1]
+        index = faiss.IndexFlatL2(dim)
+        index.add(emb_matrix)
+    save_index(index, metadata, index_file, meta_file)
+    return index, metadata
+
+
+def save_index(
+    index: faiss.IndexFlatL2,
+    metadata: List[Dict[str, str]],
+    index_file: str = INDEX_FILE,
+    meta_file: str = META_FILE,
+) -> None:
+    """Persist index and metadata to disk."""
+    faiss.write_index(index, index_file)
+    with open(meta_file, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, ensure_ascii=False)
+
+
+def load_index(
+    index_file: str = INDEX_FILE,
+    meta_file: str = META_FILE,
+) -> Tuple[faiss.IndexFlatL2, List[Dict[str, str]]]:
+    """Load index and metadata from disk."""
+    index = faiss.read_index(index_file)
+    with open(meta_file, "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+    return index, metadata
+
+
+def ensure_index(
+    sources: List[Dict[str, str]],
+    index_file: str = INDEX_FILE,
+    meta_file: str = META_FILE,
+) -> Tuple[faiss.IndexFlatL2, List[Dict[str, str]]]:
+    """Load existing index or build a new one from sources."""
+    if os.path.exists(index_file) and os.path.exists(meta_file):
+        return load_index(index_file, meta_file)
+    return build_index(sources, index_file=index_file, meta_file=meta_file)
+
+
+def search_index(
+    query: str,
+    k: int,
+    index: faiss.IndexFlatL2,
+    metadata: List[Dict[str, str]],
+) -> List[Dict[str, str]]:
+    """Retrieve ``k`` most similar chunks to ``query`` from ``index``."""
+    if index.ntotal == 0:
+        return []
+    emb = np.array([_embed_text(query)], dtype="float32")
+    _, idxs = index.search(emb, k)
+    results: List[Dict[str, str]] = []
+    for i in idxs[0]:
+        if 0 <= i < len(metadata):
+            results.append(metadata[i])
+    return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ gradio
 openai>=1.0.0
 PyPDF2
 python-dotenv
+faiss-cpu
+numpy


### PR DESCRIPTION
## Summary
- add `rag_faiss` module to build/load FAISS indices and search embeddings
- integrate retrieval into `pirjo_pipeline` so the analyst works on relevant chunks
- include FAISS dependencies in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b04e86148326ab2aabb305be3bef