### PR TITLE
Remove placeholder function definition

### DIFF
--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -73,8 +73,6 @@ def extract_sources(files: List[str]) -> List[Dict[str, str]]:
                 )
     return sources
 
-def analista_de_fuentes(title: str, sources: List[Dict[str, str]]) -> str:
-
 
 def analista_de_fuentes(title: str, chunks: List[Dict[str, str]]) -> str:
 


### PR DESCRIPTION
## Summary
- eliminate stray empty `analista_de_fuentes` definition so only the implemented function remains

## Testing
- `pytest -q`
- `python main.py` *(interrupts after launching server)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7afa7ac8326a7fc6565c1885892