### PR TITLE
Ensure PIRJO introduction uses five paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # INTRODUCCION_AGENTES
 
-Asistente de Introducciones de Investigación (PIRJO). El sistema analiza PDFs proporcionados y genera una introducción académica siguiendo los bloques PIRJO (Propósito, Importancia, Relevancia, Justificación, Originalidad).
+Asistente de Introducciones de Investigación (PIRJO). El sistema analiza PDFs proporcionados y genera una introducción académica de cinco párrafos siguiendo los bloques PIRJO (Problema, Información relevante, Restricción, Justificación y Objetivo).
 
 ## Configuración
 

--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -128,9 +128,10 @@ def metodologo_pirjo(bullets: str) -> Dict[str, str]:
 def redactor_academico(blocks: Dict[str, str]) -> str:
     """Create the final introduction from PIRJO blocks."""
     prompt = (
-        "Eres un redactor académico. Con los bloques PIRJO dados en formato JSON, escribe una "
-        "introducción cohesionada de 2-3 párrafos en estilo formal. Asegúrate de incluir las "
-        "citas cuando se proporcionen en los bloques.\n\n" + json.dumps(blocks, ensure_ascii=False)
+        "Eres un redactor académico. Con los bloques PIRJO dados en formato JSON, redacta una "
+        "introducción de cinco párrafos, un párrafo para cada bloque (P, I, R, J y O) y en ese "
+        "orden inalterable. Mantén un estilo formal e incluye las citas cuando se proporcionen."\
+        "\n\n" + json.dumps(blocks, ensure_ascii=False)
     )
     return _call_openai(prompt, system="Agente Redactor Académico")
 

--- a/tests/test_redactor_prompt.py
+++ b/tests/test_redactor_prompt.py
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pirjo_pipeline
+
+
+def test_redactor_prompt_mentions_five_paragraphs(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt, system="", client=None):
+        captured["prompt"] = prompt
+        return ""
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    blocks = {"P": "p", "I": "i", "R": "r", "J": "j", "O": "o"}
+    pirjo_pipeline.redactor_academico(blocks)
+    assert "cinco párrafos" in captured["prompt"]
+    assert "orden inalterable" in captured["prompt"]


### PR DESCRIPTION
## Summary
- enforce five-paragraph PIRJO structure in redactor
- document PIRJO blocks as Problema, Información relevante, Restricción, Justificación y Objetivo
- add unit test verifying prompt requires five paragraphs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ea4f9eb8832691f7ea4cc48cabac