### PR TITLE
Generate PIRJO blocks via separate JSON calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Asistente de Introducciones de Investigación (PIRJO). El sistema analiza PDFs p
 
 PIRJO analiza PDFs de artículos o tesis y genera de forma automática una introducción académica estructurada en cinco párrafos según los bloques PIRJO.
 
+## Detalles de implementación
+
+El módulo `metodologo_pirjo` solicita al modelo un JSON independiente para cada bloque (P, I, R, J y O) y luego combina las respuestas antes de redactar la introducción final.
+
 ## Objetivo
 
 Ofrecer una herramienta que agilice la redacción de introducciones de investigación a partir de la información extraída de los documentos proporcionados.

--- a/tests/test_metodologo_pirjo_blocks.py
+++ b/tests/test_metodologo_pirjo_blocks.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import json
+import re
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pirjo_pipeline
+
+
+def test_metodologo_pirjo_makes_separate_calls(monkeypatch):
+    prompts = []
+
+    def fake_call(prompt, system="", client=None):
+        prompts.append(prompt)
+        match = re.search(r"bloque ([PIRJO])", prompt)
+        letter = match.group(1) if match else "X"
+        return json.dumps({letter: letter.lower()})
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    bullets = "- ejemplo"
+    blocks = pirjo_pipeline.metodologo_pirjo(bullets)
+
+    assert len(prompts) == 5
+    assert blocks == {k: k.lower() for k in "PIRJO"}


### PR DESCRIPTION
## Summary
- request a JSON response per PIRJO block and merge them for downstream use
- document that each block is generated through an independent JSON call
- add unit test ensuring five calls for P, I, R, J, O

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f7ce00b88326a2d1f0599cf5019f