### PR TITLE
Add reviewer agent for APA citations in PIRJO pipeline

### DIFF
--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -156,6 +156,16 @@ def redactor_academico(blocks: Dict[str, str]) -> str:
     return _call_openai(prompt, system="Agente Redactor Académico")
 
 
+def revisor_citas_referencias(text: str) -> str:
+    """Review text and ensure citations and references in APA 7 format."""
+    prompt = (
+        "Eres un revisor académico. Verifica que el texto incluya citas en el cuerpo "
+        "y agrega una sección final titulada \"Referencias\" con las entradas en formato APA 7.\n\n"
+        f"Texto:\n{text}"
+    )
+    return _call_openai(prompt, system="Agente Revisor Académico")
+
+
 def retrieve_relevant_chunks(
     title: str,
     sources: List[Dict[str, str]],
@@ -177,6 +187,7 @@ def generate_introduction(
     bullets = analista_de_fuentes(title, objective, summary, chunks)
     blocks = metodologo_pirjo(bullets)
     introduction = redactor_academico(blocks)
+    introduction = revisor_citas_referencias(introduction)
     return {
         "introduction": introduction,
         "blocks": blocks,

--- a/tests/test_revisor_prompt.py
+++ b/tests/test_revisor_prompt.py
@@ -1,0 +1,17 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pirjo_pipeline
+
+
+def test_revisor_prompt_mentions_apa(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt, system="", client=None):
+        captured["prompt"] = prompt
+        return ""
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    pirjo_pipeline.revisor_citas_referencias("texto")
+    assert "APA 7" in captured["prompt"]
+    assert "Referencias" in captured["prompt"]


### PR DESCRIPTION
## Summary
- add `revisor_citas_referencias` agent to ensure in-text citations and APA references
- integrate the reviewer into the PIRJO introduction generation
- cover reviewer prompt instructions with new unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6306d00832692f6d98ade3753be