### PR TITLE
Agregar verificador de bibliografía basado en PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ PIRJO analiza PDFs de artículos o tesis y genera de forma automática una intro
 
 El módulo `metodologo_pirjo` solicita al modelo un JSON independiente para cada bloque (P, I, R, J y O) y luego combina las respuestas antes de redactar la introducción final.
 
+Para evitar referencias inventadas, la etapa de revisión se sustituye por un verificador
+que extrae las citas directamente de los fragmentos recuperados en la base FAISS y
+construye una sección de *Referencias* únicamente con los nombres de los PDFs
+utilizados.
+
 ## Objetivo
 
 Ofrecer una herramienta que agilice la redacción de introducciones de investigación a partir de la información extraída de los documentos proporcionados.

--- a/tests/test_metodologo_pirjo_blocks.py
+++ b/tests/test_metodologo_pirjo_blocks.py
@@ -22,3 +22,15 @@ def test_metodologo_pirjo_makes_separate_calls(monkeypatch):
 
     assert len(prompts) == 5
     assert blocks == {k: k.lower() for k in "PIRJO"}
+
+
+def test_metodologo_prompt_mentions_citations(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt, system="", client=None):
+        captured.setdefault("prompts", []).append(prompt)
+        return json.dumps({"P": "p"})
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    pirjo_pipeline.metodologo_pirjo("- ejemplo [f:1:1]")
+    assert any("citas" in p for p in captured["prompts"])

--- a/tests/test_verificador_bibliografia.py
+++ b/tests/test_verificador_bibliografia.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pirjo_pipeline
+
+
+def test_verificador_uses_only_known_sources():
+    text = "Dato [doc1.pdf:1:1] y más [doc2.pdf:2:1]."
+    sources = [
+        {"file": "doc1.pdf", "page": 1, "chunk": 1, "text": ""},
+        {"file": "doc2.pdf", "page": 2, "chunk": 1, "text": ""},
+    ]
+    result = pirjo_pipeline.verificador_bibliografia(text, sources)
+    assert "Referencias" in result
+    assert "- doc1.pdf" in result
+    assert "- doc2.pdf" in result
+
+
+def test_verificador_ignores_unknown_citations():
+    text = "Dato [doc3.pdf:1:1]."
+    sources = [{"file": "doc1.pdf", "page": 1, "chunk": 1, "text": ""}]
+    result = pirjo_pipeline.verificador_bibliografia(text, sources)
+    assert "Referencias" not in result


### PR DESCRIPTION
## Resumen
- Reforzar el flujo PIRJO para mantener las citas originales de los fragmentos recuperados.
- Añadir un verificador que construye la sección de referencias únicamente con los PDFs citados.

## Pruebas
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d72949f48326b75bd98c00f7727a