### PR TITLE
Add manager and reference agents for PIRJO pipeline

### DIFF
--- a/tests/test_manager_prompt.py
+++ b/tests/test_manager_prompt.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import json
+
+# Ensure project root on path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pirjo_pipeline
+
+
+def test_manager_prompt_mentions_title_and_objective(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt, system="", client=None):
+        captured["prompt"] = prompt
+        return json.dumps({"P": "p", "I": "i", "R": "r", "J": "j", "O": "o"})
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    blocks = {k: k.lower() for k in "PIRJO"}
+    pirjo_pipeline.agente_manager("Título", "Objetivo", blocks)
+    assert "Título" in captured["prompt"]
+    assert "Objetivo" in captured["prompt"]

--- a/tests/test_redactor_prompt.py
+++ b/tests/test_redactor_prompt.py
@@ -16,3 +16,4 @@ def test_redactor_prompt_mentions_five_paragraphs(monkeypatch):
     pirjo_pipeline.redactor_academico(blocks)
     assert "cinco párrafos" in captured["prompt"]
     assert "orden inalterable" in captured["prompt"]
+    assert "500 y 700 palabras" in captured["prompt"]

--- a/tests/test_verificador_bibliografia.py
+++ b/tests/test_verificador_bibliografia.py
@@ -10,14 +10,19 @@ def test_verificador_uses_only_known_sources():
         {"file": "doc1.pdf", "page": 1, "chunk": 1, "text": ""},
         {"file": "doc2.pdf", "page": 2, "chunk": 1, "text": ""},
     ]
-    result = pirjo_pipeline.verificador_bibliografia(text, sources)
+    metadata = {
+        "doc1.pdf": {"author": "Autor1", "title": "Título1", "year": "2020"},
+        "doc2.pdf": {"author": "Autor2", "title": "Título2", "year": "2021"},
+    }
+    result = pirjo_pipeline.verificador_bibliografia(text, sources, metadata)
     assert "Referencias" in result
-    assert "- doc1.pdf" in result
-    assert "- doc2.pdf" in result
+    assert "- Autor1 (2020). Título1." in result
+    assert "- Autor2 (2021). Título2." in result
 
 
 def test_verificador_ignores_unknown_citations():
     text = "Dato [doc3.pdf:1:1]."
     sources = [{"file": "doc1.pdf", "page": 1, "chunk": 1, "text": ""}]
-    result = pirjo_pipeline.verificador_bibliografia(text, sources)
+    metadata = {"doc1.pdf": {"author": "Autor", "title": "Título", "year": "2020"}}
+    result = pirjo_pipeline.verificador_bibliografia(text, sources, metadata)
     assert "Referencias" not in result


### PR DESCRIPTION
## Summary
- Add `agente_manager` to review PIRJO blocks against the title and objective
- Expand reference handling with metadata-driven `verificador_bibliografia`
- Instruct redactor to keep introductions between 500 and 700 words and add tests

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m pip install pytest --break-system-packages` *(fails: could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e672bfe48326bf28fa33ab5aa759