### PR TITLE
Improve PIRJO block display

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,12 +6,30 @@ from pirjo_pipeline import generate_introduction
 
 
 def run_pipeline(title: str, objective: str, summary: str, files: List[gr.File]) -> tuple:
-    """Execute the PIRJO pipeline and format outputs for Gradio."""
+    """Execute the PIRJO pipeline and format outputs for Gradio.
+
+    The introduction is returned as a single string while the PIRJO blocks are
+    rendered in a human friendly way (one block per section with the full
+    Spanish label) instead of raw JSON.
+    """
+
     file_paths = [f.name for f in files] if files else []
     if not title or not objective or not summary or not file_paths:
         return "Se requiere título, objetivo, resumen y al menos un PDF.", "", ""
+
     result = generate_introduction(title, objective, summary, file_paths)
-    blocks_text = "\n".join(f"{k}: {v}" for k, v in result["blocks"].items())
+
+    block_labels = {
+        "P": "Problema",
+        "I": "Información relevante",
+        "R": "Restricción o brecha",
+        "J": "Justificación",
+        "O": "Objetivo",
+    }
+    blocks_text = "\n\n".join(
+        f"{block_labels.get(k, k)}:\n{v}" for k, v in result["blocks"].items()
+    )
+
     processed = ", ".join(result["files"])
     return result["introduction"], blocks_text, processed
 


### PR DESCRIPTION
## Summary
- Format PIRJO blocks with full Spanish labels for clearer Gradio display.
- Preserve introduction output and list of processed files.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a643568d6c8326bfcbd43fc0561c17