### PR TITLE
feat: ensure I agent creates per-source summaries

### DIFF
--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -153,12 +153,21 @@ def metodologo_pirjo(bullets: str) -> Dict[str, str]:
     }
     results: Dict[str, str] = {}
     for clave, nombre in bloques.items():
-        prompt = (
-            f"Convierte las viñetas siguientes en el bloque {clave} ({nombre}) con 2-3 "
-            f"oraciones claras. Responde estrictamente en JSON con la clave \"{clave}\". "
-            "Mantén las citas entre corchetes exactamente como aparecen.\n\n"
-            f"Viñetas:\n{bullets}"
-        )
+        if clave == "I":
+            prompt = (
+                "Convierte las viñetas siguientes en mini-resúmenes de cada fuente citada "
+                "para el bloque I (Información relevante). Menciona autor y año cuando sea "
+                "posible. Responde estrictamente en JSON con la clave \"I\". Mantén las citas "
+                "entre corchetes exactamente como aparecen.\n\n"
+                f"Viñetas:\n{bullets}"
+            )
+        else:
+            prompt = (
+                f"Convierte las viñetas siguientes en el bloque {clave} ({nombre}) con 2-3 "
+                f"oraciones claras. Responde estrictamente en JSON con la clave \"{clave}\". "
+                "Mantén las citas entre corchetes exactamente como aparecen.\n\n"
+                f"Viñetas:\n{bullets}"
+            )
         system = f"Agente {clave} - {nombre}"
         content = _call_openai(prompt, system=system)
         try:

--- a/tests/test_metodologo_pirjo_blocks.py
+++ b/tests/test_metodologo_pirjo_blocks.py
@@ -34,3 +34,19 @@ def test_metodologo_prompt_mentions_citations(monkeypatch):
     monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
     pirjo_pipeline.metodologo_pirjo("- ejemplo [f:1:1]")
     assert any("citas" in p for p in captured["prompts"])
+
+
+def test_metodologo_prompt_for_I_requests_mini_summaries(monkeypatch):
+    prompts = []
+
+    def fake_call(prompt, system="", client=None):
+        prompts.append(prompt)
+        match = re.search(r"bloque ([PIRJO])", prompt)
+        letter = match.group(1) if match else "X"
+        return json.dumps({letter: letter.lower()})
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    pirjo_pipeline.metodologo_pirjo("- ejemplo [f:1:1]")
+
+    i_prompt = prompts[1].lower()
+    assert "mini-res" in i_prompt and "fuente" in i_prompt


### PR DESCRIPTION
## Summary
- Adjust the I agent prompt to generate mini-resumes for each cited PDF
- Cover the new behaviour with a unit test checking the prompt content

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6473f98648326ad0acc98ea7727aa