### PR TITLE
Add scientific writer agent and export options

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,6 +34,39 @@ def run_pipeline(title: str, objective: str, summary: str, files: List[gr.File])
     return result["introduction"], blocks_text, processed
 
 
+def export_to_docx(text: str) -> str:
+    """Generate a DOCX file from the provided text and return its path."""
+    from docx import Document
+    import tempfile
+    import os
+
+    doc = Document()
+    for line in text.split("\n"):
+        doc.add_paragraph(line)
+    tmp_dir = tempfile.mkdtemp()
+    file_path = os.path.join(tmp_dir, "resultado.docx")
+    doc.save(file_path)
+    return file_path
+
+
+def export_to_pdf(text: str) -> str:
+    """Generate a simple PDF file from the provided text and return its path."""
+    from fpdf import FPDF
+    import tempfile
+    import os
+
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    for line in text.split("\n"):
+        pdf.multi_cell(0, 10, line)
+    tmp_dir = tempfile.mkdtemp()
+    file_path = os.path.join(tmp_dir, "resultado.pdf")
+    pdf.output(file_path)
+    return file_path
+
+
 def build_demo() -> gr.Blocks:
     with gr.Blocks(css=".scrollable textarea {overflow-y: auto; max-height: 500px;}") as demo:
         gr.Markdown("### Asistente de Introducciones de Investigación (PIRJO)")
@@ -44,7 +77,7 @@ def build_demo() -> gr.Blocks:
             pdfs = gr.File(label="PDFs", file_count="multiple", file_types=[".pdf"])
         btn = gr.Button("Generar Introducción")
         intro = gr.Textbox(
-            label="Introducción",
+            label="Resultado final",
             lines=20,
             max_lines=20,
             autoscroll=True,
@@ -52,7 +85,13 @@ def build_demo() -> gr.Blocks:
         )
         blocks = gr.Textbox(label="Bloques PIRJO", lines=8)
         files_out = gr.Textbox(label="Archivos procesados")
+        download_word = gr.File(label="Descargar Word")
+        download_pdf = gr.File(label="Descargar PDF")
+        export_word = gr.Button("Exportar a Word")
+        export_pdf = gr.Button("Exportar a PDF")
         btn.click(run_pipeline, inputs=[title, objective, summary, pdfs], outputs=[intro, blocks, files_out])
+        export_word.click(export_to_docx, inputs=intro, outputs=download_word)
+        export_pdf.click(export_to_pdf, inputs=intro, outputs=download_pdf)
     return demo
 
 

--- a/pirjo_pipeline.py
+++ b/pirjo_pipeline.py
@@ -207,6 +207,17 @@ def redactor_academico(blocks: Dict[str, str]) -> str:
     return _call_openai(prompt, system="Agente Redactor Académico")
 
 
+def redactor_cientifico(blocks: Dict[str, str]) -> str:
+    """Combine PIRJO blocks into a single coherent scientific text."""
+    prompt = (
+        "Une todos los bloques PIRJO proporcionados en el siguiente JSON en un texto "
+        "coherente con estilo de artículo científico. Evita listar las letras de los "
+        "bloques y mantén la redacción en español.\n\n" + json.dumps(blocks, ensure_ascii=False)
+    )
+    system = "Un experto redactor de artículos científicos"
+    return _call_openai(prompt, system=system)
+
+
 def revisor_citas_referencias(text: str) -> str:
     """Review text and ensure citations and references in APA 7 format."""
     prompt = (
@@ -290,7 +301,7 @@ def generate_introduction(
     bullets, chunks = retrieve_relevant_chunks(title, objective, summary, sources)
     blocks = metodologo_pirjo(bullets)
     blocks = agente_manager(title, objective, blocks)
-    introduction = redactor_academico(blocks)
+    introduction = redactor_cientifico(blocks)
     introduction = revisor_citas_referencias(introduction)
     introduction = verificador_bibliografia(introduction, chunks, metadata)
     return {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ numpy
 tiktoken
 
 sentence-transformers
+python-docx
+fpdf2

--- a/tests/test_redactor_cientifico_prompt.py
+++ b/tests/test_redactor_cientifico_prompt.py
@@ -1,0 +1,19 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import pirjo_pipeline
+
+
+def test_redactor_cientifico_prompt_is_coherent(monkeypatch):
+    captured = {}
+
+    def fake_call(prompt, system="", client=None):
+        captured["prompt"] = prompt
+        captured["system"] = system
+        return ""
+
+    monkeypatch.setattr(pirjo_pipeline, "_call_openai", fake_call)
+    blocks = {"P": "p", "I": "i", "R": "r", "J": "j", "O": "o"}
+    pirjo_pipeline.redactor_cientifico(blocks)
+    assert "texto coherente" in captured["prompt"]
+    assert "experto redactor" in captured["system"]


### PR DESCRIPTION
## Summary
- add `redactor_cientifico` agent to turn PIRJO blocks into coherent scientific prose
- expose final text in UI with export buttons for Word and PDF
- cover new writer agent with unit test

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement python-docx)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64c7295e4832690b698962f3ed9a5